### PR TITLE
fixed: first visit cookie not set

### DIFF
--- a/src/util/Api.ts
+++ b/src/util/Api.ts
@@ -18,13 +18,21 @@ class API {
         this._location = "WebDev";
         this._randomPassLength = 15;
         let cookies = new Cookies();
-        let {token, server} = cookies.get("token");
-        console.log(token)
-        if(token) {
-            this._token = token;
-            this._headers = {'Authorization': 'Bearer ' + this._token}
-            this._server = server
-        }else this._server = address!;
+        if(!cookies.get("token")) {
+            this._server = address!;
+        }
+        else {
+            let {token, server} = cookies.get("token");
+            console.log(token)
+            if(token) {
+                this._token = token;
+                this._headers = {'Authorization': 'Bearer ' + this._token}
+                this._server = server
+            }
+            else {
+                this._server = address!; 
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
When I tried to run this on machine it didn't work at first. Reading cookie twice - once to see if it exists only at startup (where it currently may not yet exist until successfully authenticated)