### PR TITLE
Passwordreset

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/util/Api.ts
+++ b/src/util/Api.ts
@@ -36,6 +36,30 @@ class API {
     }
 
     /**
+     * Change an aleady authenticaed User's password
+     * @param {string} username - Username to login with
+     * //@param {string} password - Password to login with
+     * @param {string} newpass = Password to change to
+     * @param {string} token - Token received upon authentication
+     * @returns {Promise<string>} The stringified post response.
+     */
+     static async changePassword(username: string, newpass: string, token: string, server:string): Promise<string>{
+        
+        const ptokres = await axios.post(server + "/api/passwordreset", {
+            username: username},
+            {headers: API._getHeader(token)}
+        );
+        
+        const res = await axios.put(server + "/user/" + username +"/password", {
+            password: newpass},
+            {headers: API._getHeader(ptokres.data)} // should this *not* be a bearer token?
+                                                    // do we also need to then send "token"?
+        );
+        
+        return JSON.stringify(res)
+    }
+
+    /**
      * Get all AD users
      * @returns {Promise<User[]>} The Axios response
      */

--- a/src/util/Api.ts
+++ b/src/util/Api.ts
@@ -36,24 +36,35 @@ class API {
     }
 
     /**
-     * Change an aleady authenticaed User's password
-     * @param {string} username - Username to login with
-     * //@param {string} password - Password to login with
-     * @param {string} newpass = Password to change to
-     * @param {string} token - Token received upon authentication
-     * @returns {Promise<string>} The stringified post response.
+     * Get token for password change for a user
+     * @param {string} username - Username for which token is needed
+     * @param {string} token - Token received upon authentication for webdev user
+     * @returns {Promise<string>} The password reset token
      */
-     static async changePassword(username: string, newpass: string, token: string, server:string): Promise<string>{
+     static async passwordToken(username: string, token: string, server:string): Promise<string>{
         
-        const ptokres = await axios.post(server + "/api/passwordreset", {
+        const res = await axios.post(server + "/api/passwordreset", {
             username: username},
             {headers: API._getHeader(token)}
         );
+
+        return res.data
+    }
+
+    /**
+     * Change a user's password
+     * @param {string} username = Username of authenitcated user that can change password
+     * @param {string} newpass = Password to replace old password
+     * @param {string} token = Token to for authenticated user changing password
+     * @returns {Promise<string>} The stringified put response.
+     */
+     static async changePassword(username: string, newpass: string, token: string, server:string): Promise<string>{
+        
+        const ptok:string = JSON.stringify(this.passwordToken(username,token,server))
         
         const res = await axios.put(server + "/user/" + username +"/password", {
             password: newpass},
-            {headers: API._getHeader(ptokres.data)} // should this *not* be a bearer token?
-                                                    // do we also need to then send "token"?
+            {headers: API._getHeader(ptok)}
         );
         
         return JSON.stringify(res)

--- a/src/util/tests/Api.test.tsx
+++ b/src/util/tests/Api.test.tsx
@@ -1,0 +1,12 @@
+import { cleanup } from "@testing-library/react";
+import API from "../Api";
+
+afterEach(cleanup)
+
+/*it('Should return invalid API', () => {
+    expect(API.getTokenFromAPI("http://addict-api.acmuic.org", "test", "test")).rejects.toThrow("Invalid username or password");
+})*/
+
+it('should return true',() => {
+    true
+})


### PR DESCRIPTION
Thunder Client now gets a 200 OK when running the same requests as this code. 

*however* -->

 1. new password does not seem to be valid for 'nottestcreate' user, thunder client notes in the response when trying to authenticate, correctly, that nottestcreate user is not in the "WebDev" group

 2. couldn't create a new user to test with because add user in api now just responds that the user doesn't exist,
even though this api was used to add nottestcreate a few weeks ago.)

also: react test api skeleton only checked in for Api class, but didn't start writing the test because login for modified user doesn't seem to work yet as per 1, above.