### PR TITLE
ChangePassword page

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import HomeUnauthenticated from './pages/HomeUnauthenticated';
 import Home from './pages/Home';
 import Users from './pages/Users';
 import Create from './pages/Create';
+import ChangePassword from './pages/ChangePassword';
 import PasswordReset from './pages/PasswordReset';
 import {createStore} from 'redux';
 import { Provider } from 'react-redux';
@@ -27,6 +28,7 @@ ReactDOM.render(
             <Route path="users" element={<Users />} />
             <Route path="create" element={<Create />} />
             <Route path="password-reset" element={<PasswordReset />} />
+            <Route path="change-password" element={<ChangePassword />} />
           </Routes>
       </BrowserRouter>
     </Provider>

--- a/src/pages/ChangePassword.tsx
+++ b/src/pages/ChangePassword.tsx
@@ -1,0 +1,30 @@
+import { useSelector } from "react-redux";
+import { apiReducerState } from "../redux/reducers/apikey";
+import API from "../util/Api";
+import { useSearchParams } from "react-router-dom";
+
+export default function ChangePassword(): JSX.Element {
+    let username: string = ""
+    let newpass: string = ""
+
+    const server = useSelector((state: apiReducerState) => state.server);
+    const [searchParams, setSearchParams] = useSearchParams();
+    
+    async function ChangePass() {
+        const apikey = searchParams.get("token")
+        console.log(apikey)
+        if (apikey) {
+            alert(await API.changePassword(username,newpass,apikey,server));
+        }
+    }
+    return (
+    <div>
+        <h1>Change password</h1><br/>
+        <label><h2>Username:</h2></label>
+        <input type="text" onChange = {event => username = event.target.value}/><br/>
+        <h2>New password</h2>
+        <input type="text" onChange = {event => newpass = event.target.value}/><br/>
+        
+        <input type="button" value="Submit" onClick={ChangePass}/>
+    </div>)
+}

--- a/src/pages/ChangePassword.tsx
+++ b/src/pages/ChangePassword.tsx
@@ -23,7 +23,7 @@ export default function ChangePassword(): JSX.Element {
         <label><h2>Username:</h2></label>
         <input type="text" onChange = {event => username = event.target.value}/><br/>
         <h2>New password</h2>
-        <input type="text" onChange = {event => newpass = event.target.value}/><br/>
+        <input type="password" onChange = {event => newpass = event.target.value}/><br/>
         
         <input type="button" value="Submit" onClick={ChangePass}/>
     </div>)

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,5 +3,5 @@ import { apiReducerState } from "../redux/reducers/apikey"
 
 export default function Home(): JSX.Element {
     const apikey = useSelector((state: apiReducerState) => state.key)
-    return <h1>Home {apikey}</h1>
+    return (<div><h1>Home</h1><br /> <h3>{apikey}</h3></div>)
 }

--- a/src/pages/PasswordReset.tsx
+++ b/src/pages/PasswordReset.tsx
@@ -10,7 +10,8 @@ export default function PasswordReset(): JSX.Element {
     const apikey = useSelector((state: apiReducerState) => state.key);
 
     async function ResetPassword() {
-        alert(await(API.passwordToken(username,apikey,server)));
+        alert("http://localhost:3000/change-password?token=" + await(API.passwordToken(username,apikey,server)));
+        
     }
     return (
     <div>

--- a/src/util/Api.ts
+++ b/src/util/Api.ts
@@ -60,11 +60,9 @@ class API {
      */
      static async changePassword(username: string, newpass: string, token: string, server:string): Promise<string>{
         
-        const ptok:string = await this.passwordToken(username,token,server)
-        
         const res = await axios.put(server + "/user/" + username +"/password", {
             password: newpass},
-            {headers: API._getHeader(ptok)}
+            {headers: API._getHeader(token)}
         );
         
         return JSON.stringify(res)


### PR DESCRIPTION
change-password page created but gets error on submission

UPDATE: when I tested this, it *does* appear to work (with 200 success responses in the dialog for both users I tested). I can send details. Or if anyone wants to approve the pull request I'm creating now I can show you all at the next meeting.

note: error handling could be improved. I was indeed able to produce errors by 
a. entering a new password AD did not like
b. entering the wrong username on the "new" page - actually I think since the user is specified (and set per the token received) on the previous page, perhaps it should be non editable here?

in both cases the page did fail silently... (so probably that could be improved at some point)